### PR TITLE
Fix ReferenceError: localMediaStream

### DIFF
--- a/src/html5-qrcode.js
+++ b/src/html5-qrcode.js
@@ -25,6 +25,7 @@
     var video = $('#html5_qrcode_video').get(0);
     var canvas;
     var context; 
+    var localMediaStream;
     
     $('#qr-canvas').each(function(index, element) {
       canvas = element;


### PR DESCRIPTION
When 'use strict' is in effect, you cannot just assign to magic global
variables inside an anonymous function.

Define a local in the surrounding scope so that 'scan' and
'successCallback' can share it without relying on the global namespace.

Note: this bug affected only those using non-minified source, because
whatever minifier was used by the upstream to produce lib/html5-qrcode.min.js
stripped away the 'use strict' directive!
