### PR TITLE
Better adherence to best practices

### DIFF
--- a/src/html5-qrcode.js
+++ b/src/html5-qrcode.js
@@ -1,64 +1,66 @@
 (function( $ ){
-
-  $.fn.html5_qrcode = function(qrcodeSuccess, qrcodeError, videoError) {
-    'use strict';
-    
-    var height = this.height();
-    var width = this.width();
-    
-    if (height == null) {
-      height = 250;
-    }
-    
-    if (width == null) {
-      width = 300;
-    }
-    
-    var vidElem = $('<video id="html5_qrcode_video" width="' + width + 'px" height="' + height + 'px"></video>').appendTo(this);
-    var canvasElem = $('<canvas id="qr-canvas" width="' + (width - 2) + 'px" height="' + (height - 2) + 'px" style="display:none;"></canvas>').appendTo(this);
-    
-    var video = vidElem[0];
-    var canvas = canvasElem[0];
-    var context = canvas.getContext('2d');
-    var localMediaStream;
-    
-    var scan = function() {
-      if (localMediaStream) {
-        context.drawImage(video, 0, 0, 307,250);
-
-        try {
-          qrcode.decode();
-        } catch(e) {
-          qrcodeError(e);
+  jQuery.fn.extend({
+    html5_qrcode: function(qrcodeSuccess, qrcodeError, videoError) {
+      return this.each(function() {
+        var currentElem = $( this );
+        
+        var height = currentElem.height();
+        var width = currentElem.width();
+        
+        if (height == null) {
+          height = 250;
         }
-
-        setTimeout(scan, 500);
-
-      } else {
-        setTimeout(scan,500);
-      }
-    }//end snapshot function
+        
+        if (width == null) {
+          width = 300;
+        }
+        
+        var vidElem = $('<video width="' + width + 'px" height="' + height + 'px"></video>').appendTo(currentElem);
+        var canvasElem = $('<canvas width="' + (width - 2) + 'px" height="' + (height - 2) + 'px" style="display:none;"></canvas>').appendTo(currentElem);
+        
+        var video = vidElem[0];
+        var canvas = canvasElem[0];
+        var context = canvas.getContext('2d');
+        var localMediaStream;
+        
+        var scan = function() {
+          if (localMediaStream) {
+            context.drawImage(video, 0, 0, 307,250);
     
-    window.URL = window.URL || window.webkitURL || window.mozURL || window.msURL;
-    navigator.getUserMedia  = navigator.getUserMedia || navigator.webkitGetUserMedia || navigator.mozGetUserMedia || navigator.msGetUserMedia;
-
-    var successCallback = function(stream) {
-        video.src = (window.URL && window.URL.createObjectURL(stream)) || stream;
-        localMediaStream = stream;
-
-        video.play();
-        setTimeout(scan,1000);
+            try {
+              qrcode.decode();
+            } catch(e) {
+              qrcodeError(e);
+            }
+    
+            setTimeout(scan, 500);
+    
+          } else {
+            setTimeout(scan,500);
+          }
+        }//end snapshot function
+        
+        window.URL = window.URL || window.webkitURL || window.mozURL || window.msURL;
+        navigator.getUserMedia  = navigator.getUserMedia || navigator.webkitGetUserMedia || navigator.mozGetUserMedia || navigator.msGetUserMedia;
+    
+        var successCallback = function(stream) {
+            video.src = (window.URL && window.URL.createObjectURL(stream)) || stream;
+            localMediaStream = stream;
+    
+            video.play();
+            setTimeout(scan,1000);
+        }
+    
+        // Call the getUserMedia method with our callback functions
+        if (navigator.getUserMedia) {
+            navigator.getUserMedia({video: true}, successCallback, videoError);
+        } else {
+            console.log('Native web camera streaming (getUserMedia) not supported in this browser.');
+            // Display a friendly "sorry" message to the user
+        }
+    
+        qrcode.callback = qrcodeSuccess;
+      }); // end of html5_qrcode
     }
-
-    // Call the getUserMedia method with our callback functions
-    if (navigator.getUserMedia) {
-        navigator.getUserMedia({video: true}, successCallback, videoError);
-    } else {
-        console.log('Native web camera streaming (getUserMedia) not supported in this browser.');
-        // Display a friendly "sorry" message to the user
-    }
-
-    qrcode.callback = qrcodeSuccess;
-
-  }; // end of html5_qrcode
+  });
 })( jQuery );


### PR DESCRIPTION
The code includes some structural changes:
1. Use `jQuery.fn.extend({ html5_qrcode: function(){} })` rather than `jQuery.fn.html5_qrcode = function(){}`
2. Rather than appending HTML and then querying for it, just build the HTML and store a reference to the resulting nodes. This removes the need for defining ID attributes (which eliminates the risk of name conflicts). It also ensures that users can call html5_qrcode on elements that haven't been attached to the DOM yet.
3. Always return the jQuery object to enable function chaining.
