### PR TITLE
bug fix - adding qr-canvas id

### DIFF
--- a/src/html5-qrcode.js
+++ b/src/html5-qrcode.js
@@ -16,7 +16,7 @@
         }
         
         var vidElem = $('<video width="' + width + 'px" height="' + height + 'px"></video>').appendTo(currentElem);
-        var canvasElem = $('<canvas width="' + (width - 2) + 'px" height="' + (height - 2) + 'px" style="display:none;"></canvas>').appendTo(currentElem);
+        var canvasElem = $('<canvas id="qr-canvas" width="' + (width - 2) + 'px" height="' + (height - 2) + 'px" style="display:none;"></canvas>').appendTo(currentElem);
         
         var video = vidElem[0];
         var canvas = canvasElem[0];


### PR DESCRIPTION
The dependency on element IDs goes deeper than I thought. I'm adding the qr-canvas ID back. It's not best practice, but I don't have time to restructure the code _that_ much, and my previous change breaks the core functionality. I've tested this and it resolves all known issues.
