### PR TITLE
added function to stop media streaming

### DIFF
--- a/src/html5-qrcode.js
+++ b/src/html5-qrcode.js
@@ -1,9 +1,15 @@
 (function( $ ){
   jQuery.fn.extend({
+    html5_qrcode_stop: function() {
+      return this.each(function() {
+        html5_qrcode_running = false;
+      })
+    },
     html5_qrcode: function(qrcodeSuccess, qrcodeError, videoError) {
       return this.each(function() {
         var currentElem = $( this );
-        
+        html5_qrcode_running = true;
+
         var height = currentElem.height();
         var width = currentElem.width();
         
@@ -24,6 +30,11 @@
         var localMediaStream;
         
         var scan = function() {
+          if(!html5_qrcode_running) {
+            currentElem.html("").hide();
+            localMediaStream.stop();
+            return;
+          }
           if (localMediaStream) {
             context.drawImage(video, 0, 0, 307,250);
     


### PR DESCRIPTION
The provided patch allows to stop media streaming and collaps the video upon calling html5_qrcode_stop().

For my purpose the use of a global variable is acceptable but maybe some jQuery ninja wants to suggest how to solve this nicer (or can tell me why this is not necessary at all (in which case a documentation would be nice))