### PR TITLE
Set minimum size for flex-video compatibility

### DIFF
--- a/src/html5-qrcode.js
+++ b/src/html5-qrcode.js
@@ -7,11 +7,11 @@
         var height = currentElem.height();
         var width = currentElem.width();
         
-        if (height == null) {
+        if (height == null || height < 100) {
           height = 250;
         }
         
-        if (width == null) {
+        if (width == null || width < 100) {
           width = 300;
         }
         


### PR DESCRIPTION
This makes it work with a flex-video container in foundation5
