### PR TITLE
Fixed html5_qrcode_stop function; clearTimeout wasn't working.

### DIFF
--- a/src/html5-qrcode.js
+++ b/src/html5-qrcode.js
@@ -70,8 +70,9 @@
         html5_qrcode_stop: function() {
             return this.each(function() {
                 //stop the stream and cancel timeouts
-                $(this).data('stream').stop();
-                clearTimeout($(this).data('timeout'));
+                var currentElem = $(this);
+                $.data(currentElem[0], 'stream').stop();
+                clearTimeout($.data(currentElem[0], 'timeout'));
             });
         }
     });


### PR DESCRIPTION
The reference to timeout data wasn''t working. It is now consistent with the setTimeout lines in the scan function.