### PR TITLE
Change depricated call to MediaStream.stop() to MediaStreamTrack.stop()

### DIFF
--- a/src/html5-qrcode.js
+++ b/src/html5-qrcode.js
@@ -70,7 +70,7 @@
         html5_qrcode_stop: function() {
             return this.each(function() {
                 //stop the stream and cancel timeouts
-                $(this).data('stream').stop();
+                $(this).data('stream').getTracks()[0].stop();
                 clearTimeout($(this).data('timeout'));
             });
         }


### PR DESCRIPTION
The MediaStream.stop() method is depricated. Call stop on the first track instead to remove the warning message about the deprication.