### PR TITLE
Fix deprecation warning on MediaStream.stop().

### DIFF
--- a/src/html5-qrcode.js
+++ b/src/html5-qrcode.js
@@ -70,7 +70,10 @@
         html5_qrcode_stop: function() {
             return this.each(function() {
                 //stop the stream and cancel timeouts
-                $(this).data('stream').stop();
+                $(this).data('stream').getVideoTracks().forEach(function(videoTrack) {
+                    videoTrack.stop();
+                });
+
                 clearTimeout($(this).data('timeout'));
             });
         }


### PR DESCRIPTION
There is another pull request for this: #26. And my [comment on issue #23](dwa012/html5-qrcode/issues/23#issuecomment-143057782)

I created this one, because I would like to make sure you'll close the Video track instead of the any first track you could have.

I suggest:
```js
$(this).data('stream').getVideoTracks().forEach(function(videoTrack) {
    videoTrack.stop();
});
```

Instead of
```js
$(this).data('stream').getTracks()[0].stop();
```

Would you like to know more?
https://developers.google.com/web/updates/2015/07/mediastream-deprecations?hl=en