### PR TITLE
Fix image sampling when width x height < than 300x250

### DIFF
--- a/src/html5-qrcode.js
+++ b/src/html5-qrcode.js
@@ -25,7 +25,7 @@
 
                 var scan = function() {
                     if (localMediaStream) {
-                        context.drawImage(video, 0, 0, 307, 250);
+                        context.drawImage(video, 0, 0, width, height);
 
                         try {
                             qrcode.decode();


### PR DESCRIPTION
When qr_code div element's width x height values are lower than 300 x
250, sampling process uses fixed width x height values (307 x 250)
disregarding custom values defined by user. In this case, QR reader isn't working because only part of the video is beeing captured and there is a significant loss of details.
This fix removes hard-coded width x height values and uses variables instead.