### PR TITLE
html5_qrcode_stop did not reliably cancel ongoing calls to the scan function.

### DIFF
--- a/src/html5-qrcode.js
+++ b/src/html5-qrcode.js
@@ -32,11 +32,6 @@
                         } catch (e) {
                             qrcodeError(e, localMediaStream);
                         }
-
-                        $.data(currentElem[0], "timeout", setTimeout(scan, 500));
-
-                    } else {
-                        $.data(currentElem[0], "timeout", setTimeout(scan, 500));
                     }
                 };//end snapshot function
 
@@ -49,7 +44,7 @@
                     $.data(currentElem[0], "stream", stream);
 
                     video.play();
-                    $.data(currentElem[0], "timeout", setTimeout(scan, 1000));
+                    $.data(currentElem[0], "timeout", setInterval(scan, 500));
                 };
 
                 // Call the getUserMedia method with our callback functions
@@ -74,7 +69,7 @@
                     videoTrack.stop();
                 });
 
-                clearTimeout($(this).data('timeout'));
+                clearInterval($(this).data('timeout'));
             });
         }
     });


### PR DESCRIPTION
When calling html5_qrcode_stop inside the success callback of html5_qrcode I found that sometimes scanning wouldn't stop.  This appears to be related to the way timeouts were set up - looks like a race condition when html5_qrcode_stop cancelled the timeout but the scan function set it again. 