### PR TITLE
Appending new video element each time

### DIFF
--- a/src/html5-qrcode.js
+++ b/src/html5-qrcode.js
@@ -14,7 +14,8 @@
                 if (width == null) {
                     width = 300;
                 }
-
+                //Remove current items in parent element so it does add a new one
+                currentElem.empty();
                 var vidElem = $('<video width="' + width + 'px" height="' + height + 'px"></video>').appendTo(currentElem);
                 var canvasElem = $('<canvas id="qr-canvas" width="' + (width - 2) + 'px" height="' + (height - 2) + 'px" style="display:none;"></canvas>').appendTo(currentElem);
 


### PR DESCRIPTION
Every time I click the button to start the qr code reader, another video element gets appended beneath the existing one, hereby creating multiple video views when only one is needed. I cleared the parent element just before the video and canvas gets added.