### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-#HTML5 QR Code Reader
+# HTML5 QR Code Reader
 
 
-###Description
+### Description
 --------------
 
 
@@ -10,13 +10,13 @@ This is a cross platform jQuery library to create a QRcode reader for HTML5 comp
 The decoder used for the QRcode reading is from LazarSoft
 [https://github.com/LazarSoft/jsqrcode](https://github.com/LazarSoft/jsqrcode)
 
-###Demo
+### Demo
 ----------------------
 See a demo here [http://dwa012.github.io/html5-qrcode/](http://dwa012.github.io/html5-qrcode/)
 
 
 
-###Usage
+### Usage
 ----------------------
 Include ```html5_qrcode.min.js``` in the ```lib``` directory.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
